### PR TITLE
Removed body contents in respondWithFile 304 responses. 

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -107,7 +107,7 @@ var respondWithFile = exports.respondWithFile = function(req, filePath, contentT
     if (req.headers && req.headers["if-none-match"] === etag) {
       return {
         "status": 304,
-        "body": [ "Not Modified" ],
+        "body": [],
         "headers": { "content-length": "Not Modified".length }
       };
     }


### PR DESCRIPTION
Node prints warning when 304's have a body.
