### PR TITLE
More generic routes for oauth

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -330,18 +330,27 @@ exports.Flash = function(config, nextApp) {
  *
  */
 exports.oauth2 = function(config, nextApp) {
+    
     var options = {
-        authorizationURL: 'https://www.facebook.com/dialog/oauth',
-        tokenURL: 'https://graph.facebook.com/oauth/access_token',
-        resourceURL: 'https://graph.facebook.com/me',        
+        loginRoute: '/auth/login',
+        logoutRoute: '/auth/logout',
+        callbackRoute: '/auth/callback'        
     };
     options = _.extend(options, config);
+    if (!options.host){
+        throw new Error("host is a required option")
+    }
+    if (!options.host.match(/^http/)){
+        throw new Error("host must include the protocal.");
+    }    
+    options.host = options.host.replace(/\/$/, ""); //remove trailing slash
+       
     var OAuth2 = new(require('oauth').OAuth2)(options.clientId, options.clientSecret, '', options.authorizationURL, options.tokenURL),
         bogart = require('./bogart');
     var authd = function(req) {
             if (!req.session('profile')) {
 
-                return bogart.redirect('/facebookLogin?returnUrl=' + req.pathInfo );
+                return bogart.redirect(options.loginRoute + '?returnUrl=' + req.pathInfo );
             }
             req.auth = req.auth || {};
             req.auth.profile = req.session('profile');
@@ -349,27 +358,24 @@ exports.oauth2 = function(config, nextApp) {
             return nextApp(req);
         };
     var router = bogart.router(null, authd);
-    var absoluteUri = function(req, pathInfo) {
-        return req.scheme + '://' + req.host + (!(req.port === 80 || req.port === 443) ? ':' + req.port : '') + pathInfo;
-    };
-    var facebookCallBack = "" 
-    router.get('/facebookLogin', function(req) {
-        facebookCallBack = absoluteUri(req, '/facebookCallback?returnUrl=' + encodeURIComponent(req.params.returnUrl));
+    var callbackRoute = "" 
+    router.get(options.loginRoute, function(req) {
+        callbackRoute = options.host + options.callbackRoute + '?returnUrl=' + encodeURIComponent(req.params.returnUrl);
         var url = OAuth2.getAuthorizeUrl({
             response_type: 'code',
-            redirect_uri: facebookCallBack
+            redirect_uri: callbackRoute
         });
 
         return bogart.redirect(url);
     });
 
-    router.get('/facebookLogout', function(req) {
+    router.get(options.logoutRoute, function(req) {
         req.session('profile', undefined);
 
         return bogart.redirect('/');
     });
 
-    router.get('/facebookCallback', function(req) {
+    router.get(options.callbackRoute, function(req) {
         var deffered = Q.defer();
 
         if (req.params.code) {
@@ -382,7 +388,7 @@ exports.oauth2 = function(config, nextApp) {
             //       presence does not appear to cause any issues.
             OAuth2.getOAuthAccessToken(code, {
                 grant_type: 'authorization_code',
-                redirect_uri: facebookCallBack
+                redirect_uri: callbackRoute
             }, function(err, accessToken, refreshToken) {
                 OAuth2.getProtectedResource(options.resourceURL, accessToken, function(err, body, res) {
                     try {
@@ -415,10 +421,10 @@ exports.facebook = function(config,nextApp) {
     var facebook_strategy = {
         authorizationURL: 'https://www.facebook.com/dialog/oauth',
         tokenURL: 'https://graph.facebook.com/oauth/access_token',
-        resourceURL: 'https://graph.facebook.com/me',
+        resourceURL: 'https://graph.facebook.com/me',                        
         clientId: config.clientId,
         clientSecret: config.clientSecret,
-        redirectURL: '/profile',
+        host: config.host,
         parse: function(body) {
             if (body){
                 o = JSON.parse(body);


### PR DESCRIPTION
Took out all the facebook routes and used a more generic /auth routes.  Also passed the much needed host param.

All of the routes are overridable if desired now as well.
