### PR TITLE
Middleware's 304 handling fix

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -93,7 +93,9 @@ exports.gzip = exports.Gzip = function(nextApp) {
 
                 bogart.pump(resp.body, gzip);
 
-                resp.body = toForEachable(gzip);
+                if(resp.status != 304) {
+                    resp.body = toForEachable(gzip);
+                }
                 return resp;
             });
         } else {


### PR DESCRIPTION
Fixed node's "This type of response MUST NOT have a body. Ignoring write() calls." warning on 304. `gzip` has been adding body after `directory` responded with 304.
