### PR TITLE
fixed decypher bug

### DIFF
--- a/lib/security.js
+++ b/lib/security.js
@@ -22,6 +22,6 @@ exports.decrypt = function(valueToDecrypt) {
         
         
     var str = cipher.update(valueToDecrypt, 'hex', 'utf8');
-    str += cipher.final('hex') || '';
+    str += cipher.final('utf8') || '';
     return str;
 }


### PR DESCRIPTION
Fixed a bug with the lib/security.js module, which was bombing out as of node v0.10.0. All middleware tests pass again.
