### PR TITLE
Router before/after callbacks

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -162,7 +162,7 @@ Router.prototype.respond = function (invoke) {
     return next(invoke);
   }
 
-  var allBefores = Q.all(self.beforeCallbacks.map(function(cb) { return cb(req) }));
+  var allBefores = Q.all(self.beforeCallbacks.map(function(cb) { return invoke(cb) }));
 
   return allBefores
     .then(function () {
@@ -171,7 +171,7 @@ Router.prototype.respond = function (invoke) {
       return stackApps();
     })
     .then(function(resp) {
-      var allAfters = Q.all(self.afterCallbacks.map(function(cb) { return cb(req); }));
+      var allAfters = Q.all(self.afterCallbacks.map(function(cb) { return invoke(cb); }));
 
       return allAfters.then(thenResolve(resp));
     })

--- a/lib/router.js
+++ b/lib/router.js
@@ -40,7 +40,7 @@ function Router() {
 
   var app = function (injector) {
     if (!injector.has('req')) {
-      throw new Error('Bogart Router requires an injector ' + 
+      throw new Error('Bogart Router requires an injector ' +
         'with a request dependency registered under key `req`');
     }
 
@@ -100,7 +100,7 @@ Router.prototype.after = function(cb) {
 Router.prototype.route = function(method, path /*, handlers... */) {
   var paramNames, route, originalPath = path
     , args = slice.call(arguments);
-  
+
   method = args.shift();
   path = args.shift();
   apps = args;
@@ -279,7 +279,7 @@ function makeRoute(proto) {
                 req.routeParams.splat.push(val);
               }
             });
-        }        
+        }
       }
     }
   });


### PR DESCRIPTION
Calling `Router#before` or `Router#after` was throwing stack traces (`req is not defined`).

I fixed this by calling invoke instead, which also has the nice bonus of making injected dependencies available in those callbacks
