### PR TITLE
Method middleware deletes _method from the req.params after conversion

### DIFF
--- a/lib/middleware/directory.js
+++ b/lib/middleware/directory.js
@@ -33,7 +33,7 @@ function respondWithFile(req, filePath, contentType, headers) {
       headers = contentType;
       contentType = undefined;
     }
-    
+
     contentType = mimeType(path.extname(filePath), contentType);
 
     etag = [stat.ino, stat.size, Date.parse(stat.mtime)].join('-');
@@ -47,12 +47,19 @@ function respondWithFile(req, filePath, contentType, headers) {
     }
 
     return q.when(fsp.readFile(filePath), function onSuccess(contents) {
+      headers= _.extend({
+        etag: etag,
+        'content-type': contentType
+      }, headers);
+      if (filePath.match(/\d+\.\d+\.\d+/))
+      {
+        var d = new Date();
+        d.setMonth(d.getMonth() + 3);
+        headers.Expires = d.toString();
+      }
       return {
         status: 200,
-        headers: _.extend({
-          etag: etag,
-          'content-type': contentType
-        }, headers),
+        headers: headers,
         body: [contents]
       };
     });

--- a/lib/middleware/methodOverride.js
+++ b/lib/middleware/methodOverride.js
@@ -27,11 +27,12 @@ function methodOverride(opts) {
         var method = req.headers[HTTP_METHOD_OVERRIDE_HEADER] || req.body[METHOD_OVERRIDE_PARAM_KEY];
         if (method && HTTP_METHODS[method.toUpperCase()] === true) {
           req.env.original_method = req.method;
+          delete req.params["_method"];
           req.method = method.toUpperCase();
         }
       }
     }
-    
+
     return next();
   };
 }

--- a/lib/middleware/methodOverride.js
+++ b/lib/middleware/methodOverride.js
@@ -27,8 +27,10 @@ function methodOverride(opts) {
         var method = req.headers[HTTP_METHOD_OVERRIDE_HEADER] || req.body[METHOD_OVERRIDE_PARAM_KEY];
         if (method && HTTP_METHODS[method.toUpperCase()] === true) {
           req.env.original_method = req.method;
-          delete req.params["_method"];
           req.method = method.toUpperCase();
+          if (req.params){
+            delete req.params["_method"];
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -24,17 +24,17 @@
     "email": "nrstott@gmail.com"
   },
   "dependencies": {
-    "q": "0.9.6",
+    "q": ">0.9.6",
     "jsgi": "notduncansmith/jsgi-node#patch-1",
     "mustache": "0.7.2",
     "underscore": ">=1.4.4",
     "node-uuid": ">=1.2.0",
     "parted": "git://github.com/soitgoes/parted.git#v0.1.3",
     "oauth": "=0.9.5",
-    "request": "=2.2.9",
+    "request": ">2.2.9",
     "commander": "*",
     "mkdirp": "*",
-    "sinon": "1.5.2",
+    "sinon": ">1.5.2",
     "bogart-injector": "~0.2.0",
     "negotiator": "~0.4.1",
     "inflect": "~0.3.0"


### PR DESCRIPTION
This makes it cleaner for scenarios where you create the data model from the params.  (Couch fails when you attempt to store _method property) and on other platforms it's probably annoying to store _method on your object.
